### PR TITLE
Allow killing runner with Ctrl+C

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -7,4 +7,4 @@ cd ./reference-bot-publish/ && sleep 3 && dotnet ReferenceBot.dll &
 cd ./reference-bot-publish/ && sleep 3 && dotnet ReferenceBot.dll &
 cd ./reference-bot-publish/ && sleep 3 && dotnet ReferenceBot.dll &
 
-$SHELL
+wait


### PR DESCRIPTION
This pull request allows killing the runner with Ctrl+C and it doesn't spawn a new shell each time `run.sh` is launched. Also marks the run.sh script as executable.