### PR TITLE
Updated Readme Docker Commands to use correct file paths.

### DIFF
--- a/ec-compose/README.md
+++ b/ec-compose/README.md
@@ -22,8 +22,8 @@ This repo provides a convenient way to load and run all the engine components to
 4. Inside this folder, run `build.sh`
 5. Once complete, open a terminal or command prompt, and run `docker-compose -p "ec" up --build`
 6. Once the run, it will take a moment to shut down, and then you can use the following commands to download the match logs
-    1. Match state: `docker cp ec_logger_1:/app/matchState.log ./matchState.json`
-    2. Game Complete: `docker cp ec_logger_1:/app/gameComplete.log ./gameComplete.json`
+    1. Match state: `docker cp ec_logger_1:/app/matchState.log.json ./matchState.json`
+    2. Game Complete: `docker cp ec_logger_1:/app/gameComplete.log.json ./matchState_gameComplete.json`
 
 ## Running a bot against This
 


### PR DESCRIPTION
I have found that the Readme document incorrectly identifies the docker command to download the necessary log files.
I have also gone ahead and added the necessary change to allow easy usage with the visualizer by changing the filename retrieved slightly. 