### PR TITLE
Prevent Engine falling over when unrecognised commands are used

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 .DS_Store
+
+*.user

--- a/game-engine/Engine/Handlers/Actions/NoOpActionHandler.cs
+++ b/game-engine/Engine/Handlers/Actions/NoOpActionHandler.cs
@@ -1,0 +1,15 @@
+﻿using Domain.Models;
+using Engine.Handlers.Interfaces;
+
+namespace Engine.Handlers.Actions
+{
+    public class NoOpActionHandler: IActionHandler
+    {
+        public bool IsApplicable(PlayerAction botCurrentAction) => false;
+
+        public void ProcessAction(BotObject bot)
+        {
+            // no-op
+        }
+    }
+}

--- a/game-engine/Engine/Handlers/Resolvers/ActionHandlerResolver.cs
+++ b/game-engine/Engine/Handlers/Resolvers/ActionHandlerResolver.cs
@@ -1,6 +1,7 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
 using Domain.Models;
+using Engine.Handlers.Actions;
 using Engine.Handlers.Interfaces;
 
 namespace Engine.Handlers.Resolvers
@@ -16,7 +17,13 @@ namespace Engine.Handlers.Resolvers
 
         public IActionHandler ResolveHandler(PlayerAction botCurrentAction)
         {
-            return handlers.First(handler => handler.IsApplicable(botCurrentAction));
+            var handler = handlers.FirstOrDefault(h => h.IsApplicable(botCurrentAction));
+            if (handler == null)
+            {
+                return new NoOpActionHandler();
+            }
+
+            return handler;
         }
     }
 }

--- a/game-runner/GameRunner/Services/RunnerStateService.cs
+++ b/game-runner/GameRunner/Services/RunnerStateService.cs
@@ -64,6 +64,11 @@ namespace GameRunner.Services
                 return default;
             }
 
+            if (TotalConnectedClients >= runnerConfig.BotCount)
+            {
+                return default;
+            }
+
             var botGuid = Guid.NewGuid();
             Logger.LogDebug("RunnerStateService", "Registering Bot");
             gameEngine.Client.SendAsync("BotRegistered", botGuid);


### PR DESCRIPTION
Prevents any command other than the ones the engine is aware of from causing issues such as shutdowns.

Additionally, prevents extra bots from connecting to the runner before a game starts, as well as during a game.

Isolates game state broadcasts to the registered players and engine components