### PR TITLE
Fix Effects property

### DIFF
--- a/game-engine/Engine/Services/WorldStateService.cs
+++ b/game-engine/Engine/Services/WorldStateService.cs
@@ -382,7 +382,7 @@ namespace Engine.Services
 
             if (bot != default)
             {
-                bot.Effects &= activeEffect.Effect;
+                bot.Effects &= ~activeEffect.Effect;
             }
         }
 

--- a/game-engine/EngineTests/HandlerTests/AsteroidFieldCollisionHandlerTests.cs
+++ b/game-engine/EngineTests/HandlerTests/AsteroidFieldCollisionHandlerTests.cs
@@ -48,8 +48,12 @@ namespace EngineTests.HandlerTests
             Assert.DoesNotThrow(() => WorldStateService.ApplyAfterTickStateChanges());
 
             var activeEffect = WorldStateService.GetActiveEffectByType(bot.Id, Effects.AsteroidField);
+            var botAfter = WorldStateService.GetState().PlayerGameObjects.Find(g => g.Id == bot.Id);
 
             Assert.True(activeEffect != default);
+            Assert.True(activeEffect.Effect == Effects.AsteroidField);
+            Assert.True(botAfter != default);
+            Assert.True(botAfter.Effects == Effects.AsteroidField);
             Assert.AreEqual(19, bot.Speed);
         }
         

--- a/game-engine/EngineTests/HandlerTests/GasCloudCollisionHandlerTests.cs
+++ b/game-engine/EngineTests/HandlerTests/GasCloudCollisionHandlerTests.cs
@@ -48,8 +48,12 @@ namespace EngineTests.HandlerTests
             Assert.DoesNotThrow(() => WorldStateService.ApplyAfterTickStateChanges());
 
             var activeEffect = WorldStateService.GetActiveEffectByType(bot.Id, Effects.GasCloud);
+            var botAfter = WorldStateService.GetState().PlayerGameObjects.Find(g => g.Id == bot.Id);
 
             Assert.True(activeEffect != default);
+            Assert.True(activeEffect.Effect == Effects.GasCloud);
+            Assert.True(botAfter != default);
+            Assert.True(botAfter.Effects == Effects.GasCloud);
             Assert.AreEqual(8, bot.Size);
         }
     }

--- a/game-engine/EngineTests/ServiceTests/ActionServiceTests.cs
+++ b/game-engine/EngineTests/ServiceTests/ActionServiceTests.cs
@@ -80,15 +80,20 @@ namespace EngineTests.ServiceTests
 
             Assert.DoesNotThrow(() => actionService.ApplyActionToBot(bot));
             var activeEffect = WorldStateService.GetActiveEffectByType(bot.Id, Effects.Afterburner);
+            var botAfter = WorldStateService.GetState().PlayerGameObjects.Find(g => g.Id == bot.Id);
 
             Assert.True(activeEffect != default);
             Assert.True(activeEffect.Bot.Size == 10);
             Assert.True(activeEffect.Bot.Speed == 40);
+            Assert.True(botAfter != default);
+            Assert.True(botAfter.Effects == Effects.Afterburner);
 
             Assert.DoesNotThrow(() => WorldStateService.ApplyAfterTickStateChanges());
 
             Assert.True(activeEffect.Bot.Size == 9);
             Assert.True(activeEffect.Bot.Speed == 40);
+            Assert.True(botAfter != default);
+            Assert.True(botAfter.Effects == Effects.Afterburner);
         }
 
         [Test]
@@ -104,7 +109,7 @@ namespace EngineTests.ServiceTests
 
             Assert.DoesNotThrow(() => actionService.ApplyActionToBot(bot));
             Assert.DoesNotThrow(() => WorldStateService.ApplyAfterTickStateChanges());
-
+            
             var secondAction = FakeGameObjectProvider.GetStopAfterburnerPlayerAction(bot.Id);
             bot.PendingActions = new List<PlayerAction>
             {
@@ -113,10 +118,13 @@ namespace EngineTests.ServiceTests
 
             Assert.DoesNotThrow(() => actionService.ApplyActionToBot(bot));
             var activeEffect = WorldStateService.GetActiveEffectByType(bot.Id, Effects.Afterburner);
+            var botAfter = WorldStateService.GetState().PlayerGameObjects.Find(g => g.Id == bot.Id);
 
             Assert.True(activeEffect == default);
             Assert.AreEqual(9, bot.Size);
             Assert.AreEqual(23, bot.Speed);
+            Assert.True(botAfter != default);
+            Assert.True(botAfter.Effects != Effects.Afterburner);
         }
 
         [Test]


### PR DESCRIPTION
Update WorldStateService to correctly remove Effects in PlayerGameObjects and update unit tests to check the changes to this property.