### PR TITLE
Upgrade .Net Core starter bot from .Net Core 3.1 to .Net 5

### DIFF
--- a/starter-bots/NETCoreBot/NETCoreBot/NETCoreBot.csproj
+++ b/starter-bots/NETCoreBot/NETCoreBot/NETCoreBot.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
While getting setup I noticed that my submission matches were failing with the following error in bot_log.txt

> {"date":"2021-05-18T16:16:58.763691Z","log":"It was not possible to find any compatible framework version"}
> {"date":"2021-05-18T16:16:58.763806Z","log":"The framework 'Microsoft.NETCore.App', version '3.1.0' was not found."}
> {"date":"2021-05-18T16:16:58.763818Z","log":"  - The following frameworks were found:"}
> {"date":"2021-05-18T16:16:58.763829Z","log":"      5.0.5 at [/usr/share/dotnet/shared/Microsoft.NETCore.App]"}
> {"date":"2021-05-18T16:16:58.763835Z","log":""}
> {"date":"2021-05-18T16:16:58.763846Z","log":"You can resolve the problem by installing the specified framework and/or SDK."}
> {"date":"2021-05-18T16:16:58.763852Z","log":""}
> {"date":"2021-05-18T16:16:58.763858Z","log":"The specified framework can be found at:"}
> {"date":"2021-05-18T16:16:58.763863Z","log":"  - https://aka.ms/dotnet-core-applaunch?framework=Microsoft.NETCore.App&framework_version=3.1.0&arch=x64&rid=alpine.3.13-x64"}


Upgrading my bot to .Net 5 solved this and this PR makes the same change to the starter bot so that new users won't run into the same issue.

If the submission matches should work with .Net Core 3.1 bots then this PR can be rejected.