### PR TITLE
Revert Regression on script

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -7,4 +7,4 @@ cd ./reference-bot-publish/ && sleep 3 && dotnet ReferenceBot.dll &
 cd ./reference-bot-publish/ && sleep 3 && dotnet ReferenceBot.dll &
 cd ./reference-bot-publish/ && sleep 3 && dotnet ReferenceBot.dll &
 
-$SHELL
+wait


### PR DESCRIPTION
This reverts the switch back to $SHELL, and should allow the terminal to be killed correctly